### PR TITLE
make HTTP get requests use JSON format

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -251,7 +251,10 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
       reqOpts.url = endpoints.REST_ROOT + path + '.json';
     }
 
-    if (FORMDATA_PATHS.indexOf(path) !== -1) {
+    if ((method || '').toUpperCase() === 'GET') {
+      reqOpts.headers['Content-type'] = 'application/json';
+      reqOpts.json = true;
+    } else if (FORMDATA_PATHS.indexOf(path) !== -1) {
       reqOpts.headers['Content-type'] = 'multipart/form-data';
       reqOpts.form = finalParams;
        // set finalParams to empty object so we don't append a query string


### PR DESCRIPTION
Please approve my pool request, Mr. Hiner. Media upload status requests are failing without it.